### PR TITLE
Added option to save temperature for a site only

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,10 @@
         "message": "Activate only at night",
         "description": "Label of the change auto check box"
     },
+    "siteOnlyLabel": {
+        "message": "Apply for this site only",
+        "description": "Label of the site only checkbox"
+    },
     "sunriseLabel": {
         "message": "Sunrise",
         "description": "Label of the sunrise select"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -23,6 +23,10 @@
         "message": "Habilitar sólo por la noche",
         "description": "Label of the change auto check box"
     },
+    "siteOnlyLabel": {
+        "message": "Aplicar sólo para este sitio",
+        "description": "Label of the site only checkbox"
+    },
     "sunriseLabel": {
         "message": "Salida del sol",
         "description": "Label of the sunrise select"

--- a/content_scripts/page_script.js
+++ b/content_scripts/page_script.js
@@ -94,8 +94,12 @@ var firelux = (function() {
         });
 
         browser.storage.local.get().then(function(storage) {
-            if (storage != null && storage.temperature != null) {
-                restoreStorage(storage.temperature);
+            if (storage != null && (storage.temperature != null || storage.sites != null)) {
+                if (storage.sites != null && storage.sites.hasOwnProperty(location.host)) {
+                    restoreStorage(storage.sites[location.host]);
+                } else {
+                    restoreStorage(storage.temperature);
+                }
             } else {
                 restoreStorage(null);
             }

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
     },
 
     "permissions": [
-        "storage"
+        "storage",
+        "tabs"
     ],
 
     "content_scripts": [{

--- a/popup/panel.css
+++ b/popup/panel.css
@@ -106,6 +106,16 @@ input#use-sync {
     position: absolute;
 }
 
+label[for=site-only] {
+    max-width: 80%;
+    cursor: pointer;
+}
+
+input#site-only {
+    right: 40px;
+    position: absolute;
+}
+
 button#save {
     width: 100%;
 }

--- a/popup/panel.html
+++ b/popup/panel.html
@@ -125,6 +125,18 @@
             </div>
         </div>
 
+        <div class="row" id="site-only-row">
+            <div class="col-xs-12">
+                <form class="form-inline">
+                    <div class="form-group">
+                        <label for="site-only">
+                        </label>
+                        <input type="checkbox" id="site-only" placeholder="FF9329" />
+                    </div>
+                </form>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col-xs-12">
                 <button id="save" class="btn btn-primary">


### PR DESCRIPTION
Hi, thanks for create this useful tool.
The following changes allow to save temperature for the current site only, based on host property. It requires _tabs permission_ to get the URL of opened tabs.

![firelux2](https://user-images.githubusercontent.com/1578078/63828125-1c795080-c92b-11e9-95e7-bae04304aaed.png)
